### PR TITLE
"Used by" -> "Dependents"

### DIFF
--- a/lib/whatthegem/stats/definitions.rb
+++ b/lib/whatthegem/stats/definitions.rb
@@ -27,7 +27,7 @@ module WhatTheGem
         thresholds: [T.year.decrease(now), T.month.decrease(now, 2)],
         &Time.method(:parse)
 
-      metric 'Used by', :rubygems, :reverse_dependencies, :count, thresholds: [10, 100]
+      metric 'Dependents', :rubygems, :reverse_dependencies, :count, thresholds: [10, 100]
 
       metric 'Stars', :github, :repo, :stargazers_count, thresholds: [100, 500]
       metric 'Forks', :github, :repo, :forks_count, thresholds: [5, 20]


### PR DESCRIPTION
Rename "Used by" to "Dependents" to eliminate confusion: "Used by" could be interpreted as "Used by users" count, as nothing says that it means dependent gems.