### PR TITLE
Fix File.exists? raising an error with Ruby 3.2

### DIFF
--- a/lib/whatthegem/gem/bundled.rb
+++ b/lib/whatthegem/gem/bundled.rb
@@ -24,7 +24,7 @@ module WhatTheGem
       end
 
       def self.fetch(name)
-        return NoBundle.new(name) unless File.exists?('Gemfile') && File.exists?('Gemfile.lock')
+        return NoBundle.new(name) unless File.exist?('Gemfile') && File.exist?('Gemfile.lock')
 
         definition = Bundler::Definition.build('Gemfile', 'Gemfile.lock', nil)
         spec = definition.locked_gems.specs.detect { |s| s.name == name } or return NotBundled.new(name)

--- a/spec/whatthegem/changes/shared.rb
+++ b/spec/whatthegem/changes/shared.rb
@@ -15,7 +15,9 @@ RSpec.shared_examples 'parses successfully' do |name|
   end
 end
 
-RSpec.shared_examples 'parses changelog' do |name, versions:|
+RSpec.shared_examples 'parses changelog' do |name, options = {}|
+  versions = options[:versions]
+
   context "with #{name} -- full tests" do
     let(:gem_name) { name }
     include_context 'parse changelog'


### PR DESCRIPTION
## What 

`File.exists?` was removed in Ruby 3.2 thus I replaced it with `File.exist?`

I also fixed an error in RSpec shared example where while running in Ruby 3.2 it does not forward the block keyword argument. 